### PR TITLE
Fix server build for first time setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 dist
+.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "start": "concurrently \"npm:serve:*\" -k",
-    "serve:build-server": "npm run build:server",
-    "serve:server": "nodemon ./dist/server/app.js",
-    "serve:client": "webpack-dev-server --color --config ./webpack.config.js",
-    "build:server": "tsc src/server/app.ts -inlineSourceMap -outDir dist/server --esModuleInterop --watch --preserveWatchOutput",
+    "start": "concurrently \"npm:watch:*\" -k",
+    "serve:server": "npm run build:server && node ./dist/server/app.js",
+    "watch:server": "nodemon --watch src/server -e ts --exec \"npm run serve:server\"",
+    "watch:client": "webpack-dev-server --color --config ./webpack.config.js",
+    "build:server": "tsc src/server/app.ts -inlineSourceMap -outDir dist/server --esModuleInterop --incremental --tsBuildInfoFile .tsbuildinfo",
     "build:client": "webpack --env prod --env clean",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Fix #43.

**The problem**
server serving (nodemon) and tsc watch compiling happened at the same time. When there is no dist/ folder (first time running the app), server won't start correctly until user ctrl+c the script. If there is dist/ folder, the server will serve old server code until there's any code change.

**The fix**
Since `tsc --watch` will never return, we cannot chain tsc watch with nodemon like `tsc --watch && nodemon server.js`. The nodemon serve isn't reachable. The solution is to relay on nodemon to watch file changes under `src/server`, and trigger tsc compliation whenever there's ts file changes. Note: `nodemon --watch folder` isn't recursive, therefore we have to use `-e ts` to specify file extension. To make tsc compliation incremental for perf, we use `--incremental` and `--tsBuildInfoFile` to cache project graph.


**Further reference**
* https://stackoverflow.com/questions/38276862/is-there-a-way-to-use-npm-scripts-to-run-tsc-watch-nodemon-watch
* [nodemon](https://github.com/remy/nodemon#nodemon)
* [tsc --incremental and --tsBuildInfoFile](https://www.typescriptlang.org/tsconfig/#incremental)